### PR TITLE
v0.3.1: New password length behaviour

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="fbb0c733-4aa1-4d27-87d5-c7276d8aa613" name="Default Changelist" comment="v0.3.1: New password length behaviour&#10;&#10;To address issue #13, the password length behaviour of the &#10;original APG has been reproduced. Previously, when a minLength&#10;of 5 and a maxLength of 10 was given, apg-go se the pwLength to&#10;the preferred maxLength.&#10;&#10;With v0.3.1 it will choose a random length between minLength and&#10;maxLength instead, same as the original C-lang apg did. For this&#10;the minLength has been defaulted to a sane value of 12 (instead &#10;of the 8 of the original apg). The default for maxLength stayed&#10;at 20.&#10;&#10;Also the default number of generated passwords has been changed &#10;from 1 to 6, to replicate the behaviour of the original apg.">
+    <list default="true" id="fbb0c733-4aa1-4d27-87d5-c7276d8aa613" name="Default Changelist" comment="For some reason, the tests on GH fail">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/apg.go" beforeDir="false" afterPath="$PROJECT_DIR$/apg.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/apg_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/apg_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/config.go" beforeDir="false" afterPath="$PROJECT_DIR$/config.go" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -231,7 +232,8 @@
     <MESSAGE value="v0.2.9: Replaced standard go-help with custom usage text" />
     <MESSAGE value="v0.3.0: Unified the naming convention" />
     <MESSAGE value="v0.3.1: New password length behaviour&#10;&#10;To address issue #13, the password length behaviour of the &#10;original APG has been reproduced. Previously, when a minLength&#10;of 5 and a maxLength of 10 was given, apg-go se the pwLength to&#10;the preferred maxLength.&#10;&#10;With v0.3.1 it will choose a random length between minLength and&#10;maxLength instead, same as the original C-lang apg did. For this&#10;the minLength has been defaulted to a sane value of 12 (instead &#10;of the 8 of the original apg). The default for maxLength stayed&#10;at 20.&#10;&#10;Also the default number of generated passwords has been changed &#10;from 1 to 6, to replicate the behaviour of the original apg." />
-    <option name="LAST_COMMIT_MESSAGE" value="v0.3.1: New password length behaviour&#10;&#10;To address issue #13, the password length behaviour of the &#10;original APG has been reproduced. Previously, when a minLength&#10;of 5 and a maxLength of 10 was given, apg-go se the pwLength to&#10;the preferred maxLength.&#10;&#10;With v0.3.1 it will choose a random length between minLength and&#10;maxLength instead, same as the original C-lang apg did. For this&#10;the minLength has been defaulted to a sane value of 12 (instead &#10;of the 8 of the original apg). The default for maxLength stayed&#10;at 20.&#10;&#10;Also the default number of generated passwords has been changed &#10;from 1 to 6, to replicate the behaviour of the original apg." />
+    <MESSAGE value="For some reason, the tests on GH fail" />
+    <option name="LAST_COMMIT_MESSAGE" value="For some reason, the tests on GH fail" />
   </component>
   <component name="VgoProject">
     <integration-enabled>true</integration-enabled>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,8 +6,11 @@
   <component name="ChangeListManager">
     <list default="true" id="fbb0c733-4aa1-4d27-87d5-c7276d8aa613" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/buildfiles/arch-linux/PKGBUILD" beforeDir="false" afterPath="$PROJECT_DIR$/buildfiles/arch-linux/PKGBUILD" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/apg.go" beforeDir="false" afterPath="$PROJECT_DIR$/apg.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/apg_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/apg_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/config.go" beforeDir="false" afterPath="$PROJECT_DIR$/config.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/go.mod" beforeDir="false" afterPath="$PROJECT_DIR$/go.mod" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/rand.go" beforeDir="false" afterPath="$PROJECT_DIR$/rand.go" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -49,7 +52,6 @@
   <component name="ProjectViewState">
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
-    <option name="showMembers" value="true" />
   </component>
   <component name="PropertiesComponent">
     <property name="DefaultGoTemplateProperty" value="Go Application" />
@@ -71,15 +73,15 @@
       <recent name="C:\Users\Winni Neessen\go\src\apg.go\test" />
     </key>
   </component>
-  <component name="RunManager" selected="Go Test.Test Application">
+  <component name="RunManager" selected="Go Build.Run Application (with newstyle params)">
     <configuration name="Run Application (show help text)" type="GoApplicationRunConfiguration" factoryName="Go Application">
       <module name="apg.go" />
       <working_directory value="$PROJECT_DIR$" />
       <parameters value="-h" />
       <kind value="PACKAGE" />
-      <filePath value="$PROJECT_DIR$" />
-      <package value="github.com/wneessen/apg.go" />
+      <package value="github.com/wneessen/apg-go" />
       <directory value="$PROJECT_DIR$" />
+      <filePath value="$PROJECT_DIR$" />
       <method v="2" />
     </configuration>
     <configuration name="Run Application (show version string)" type="GoApplicationRunConfiguration" factoryName="Go Application">
@@ -87,9 +89,9 @@
       <working_directory value="$PROJECT_DIR$" />
       <parameters value="-v" />
       <kind value="PACKAGE" />
-      <filePath value="$PROJECT_DIR$" />
-      <package value="github.com/wneessen/apg.go" />
+      <package value="github.com/wneessen/apg-go" />
       <directory value="$PROJECT_DIR$" />
+      <filePath value="$PROJECT_DIR$" />
       <method v="2" />
     </configuration>
     <configuration name="Run Application (with excludes)" type="GoApplicationRunConfiguration" factoryName="Go Application">
@@ -97,9 +99,9 @@
       <working_directory value="$PROJECT_DIR$" />
       <parameters value="-m 20 -x 20 -C -E abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!]" />
       <kind value="PACKAGE" />
-      <filePath value="$PROJECT_DIR$" />
-      <package value="github.com/wneessen/apg.go" />
+      <package value="github.com/wneessen/apg-go" />
       <directory value="$PROJECT_DIR$" />
+      <filePath value="$PROJECT_DIR$" />
       <method v="2" />
     </configuration>
     <configuration name="Run Application (with newstyle params and spelling and multiple pws)" type="GoApplicationRunConfiguration" factoryName="Go Application">
@@ -107,9 +109,9 @@
       <working_directory value="$PROJECT_DIR$" />
       <parameters value="-m 10 -x 10 -M SLNU -l -n 6" />
       <kind value="PACKAGE" />
-      <filePath value="$PROJECT_DIR$" />
-      <package value="github.com/wneessen/apg.go" />
+      <package value="github.com/wneessen/apg-go" />
       <directory value="$PROJECT_DIR$" />
+      <filePath value="$PROJECT_DIR$" />
       <method v="2" />
     </configuration>
     <configuration name="Run Application (with newstyle params and spelling)" type="GoApplicationRunConfiguration" factoryName="Go Application">
@@ -117,19 +119,19 @@
       <working_directory value="$PROJECT_DIR$" />
       <parameters value="-m 10 -x 10 -M SLNU -l" />
       <kind value="PACKAGE" />
-      <filePath value="$PROJECT_DIR$" />
-      <package value="github.com/wneessen/apg.go" />
+      <package value="github.com/wneessen/apg-go" />
       <directory value="$PROJECT_DIR$" />
+      <filePath value="$PROJECT_DIR$" />
       <method v="2" />
     </configuration>
     <configuration name="Run Application (with newstyle params)" type="GoApplicationRunConfiguration" factoryName="Go Application">
       <module name="apg.go" />
       <working_directory value="$PROJECT_DIR$" />
-      <parameters value="-m 20 -x 20 -M slNU" />
+      <parameters value="-M slNU" />
       <kind value="PACKAGE" />
-      <filePath value="$PROJECT_DIR$" />
-      <package value="github.com/wneessen/apg.go" />
+      <package value="github.com/wneessen/apg-go" />
       <directory value="$PROJECT_DIR$" />
+      <filePath value="$PROJECT_DIR$" />
       <method v="2" />
     </configuration>
     <configuration name="Run Application (with params)" type="GoApplicationRunConfiguration" factoryName="Go Application">
@@ -137,38 +139,38 @@
       <working_directory value="$PROJECT_DIR$" />
       <parameters value="-m 20 -x 20 -C" />
       <kind value="PACKAGE" />
-      <filePath value="$PROJECT_DIR$" />
-      <package value="github.com/wneessen/apg.go" />
+      <package value="github.com/wneessen/apg-go" />
       <directory value="$PROJECT_DIR$" />
+      <filePath value="$PROJECT_DIR$" />
       <method v="2" />
     </configuration>
     <configuration name="Run Application" type="GoApplicationRunConfiguration" factoryName="Go Application">
       <module name="apg.go" />
       <working_directory value="$PROJECT_DIR$" />
       <kind value="PACKAGE" />
-      <filePath value="$PROJECT_DIR$" />
-      <package value="github.com/wneessen/apg.go" />
+      <package value="github.com/wneessen/apg-go" />
       <directory value="$PROJECT_DIR$" />
+      <filePath value="$PROJECT_DIR$" />
       <method v="2" />
     </configuration>
     <configuration name="Benchmark Application" type="GoTestRunConfiguration" factoryName="Go Test">
       <module name="apg.go" />
       <working_directory value="$PROJECT_DIR$" />
-      <framework value="gobench" />
       <kind value="PACKAGE" />
-      <package value="github.com/wneessen/apg.go" />
+      <package value="github.com/wneessen/apg-go" />
       <directory value="$PROJECT_DIR$" />
       <filePath value="$PROJECT_DIR$" />
+      <framework value="gobench" />
       <method v="2" />
     </configuration>
     <configuration name="Test Application" type="GoTestRunConfiguration" factoryName="Go Test">
       <module name="apg.go" />
       <working_directory value="$PROJECT_DIR$" />
-      <framework value="gotest" />
       <kind value="PACKAGE" />
-      <package value="github.com/wneessen/apg.go" />
+      <package value="github.com/wneessen/apg-go" />
       <directory value="$PROJECT_DIR$" />
       <filePath value="$PROJECT_DIR$" />
+      <framework value="gotest" />
       <method v="2" />
     </configuration>
     <list>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,13 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="fbb0c733-4aa1-4d27-87d5-c7276d8aa613" name="Default Changelist" comment="">
+    <list default="true" id="fbb0c733-4aa1-4d27-87d5-c7276d8aa613" name="Default Changelist" comment="v0.3.1: New password length behaviour&#10;&#10;To address issue #13, the password length behaviour of the &#10;original APG has been reproduced. Previously, when a minLength&#10;of 5 and a maxLength of 10 was given, apg-go se the pwLength to&#10;the preferred maxLength.&#10;&#10;With v0.3.1 it will choose a random length between minLength and&#10;maxLength instead, same as the original C-lang apg did. For this&#10;the minLength has been defaulted to a sane value of 12 (instead &#10;of the 8 of the original apg). The default for maxLength stayed&#10;at 20.&#10;&#10;Also the default number of generated passwords has been changed &#10;from 1 to 6, to replicate the behaviour of the original apg.">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/apg.go" beforeDir="false" afterPath="$PROJECT_DIR$/apg.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/apg_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/apg_test.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/config.go" beforeDir="false" afterPath="$PROJECT_DIR$/config.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/go.mod" beforeDir="false" afterPath="$PROJECT_DIR$/go.mod" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/rand.go" beforeDir="false" afterPath="$PROJECT_DIR$/rand.go" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -234,7 +230,8 @@
     <MESSAGE value="New DEV branch" />
     <MESSAGE value="v0.2.9: Replaced standard go-help with custom usage text" />
     <MESSAGE value="v0.3.0: Unified the naming convention" />
-    <option name="LAST_COMMIT_MESSAGE" value="v0.3.0: Unified the naming convention" />
+    <MESSAGE value="v0.3.1: New password length behaviour&#10;&#10;To address issue #13, the password length behaviour of the &#10;original APG has been reproduced. Previously, when a minLength&#10;of 5 and a maxLength of 10 was given, apg-go se the pwLength to&#10;the preferred maxLength.&#10;&#10;With v0.3.1 it will choose a random length between minLength and&#10;maxLength instead, same as the original C-lang apg did. For this&#10;the minLength has been defaulted to a sane value of 12 (instead &#10;of the 8 of the original apg). The default for maxLength stayed&#10;at 20.&#10;&#10;Also the default number of generated passwords has been changed &#10;from 1 to 6, to replicate the behaviour of the original apg." />
+    <option name="LAST_COMMIT_MESSAGE" value="v0.3.1: New password length behaviour&#10;&#10;To address issue #13, the password length behaviour of the &#10;original APG has been reproduced. Previously, when a minLength&#10;of 5 and a maxLength of 10 was given, apg-go se the pwLength to&#10;the preferred maxLength.&#10;&#10;With v0.3.1 it will choose a random length between minLength and&#10;maxLength instead, same as the original C-lang apg did. For this&#10;the minLength has been defaulted to a sane value of 12 (instead &#10;of the 8 of the original apg). The default for maxLength stayed&#10;at 20.&#10;&#10;Also the default number of generated passwords has been changed &#10;from 1 to 6, to replicate the behaviour of the original apg." />
   </component>
   <component name="VgoProject">
     <integration-enabled>true</integration-enabled>

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ $ sudo cp apg /usr/local/bin/apg
 ## CLI parameters
 _apg.go_ replicates some of the parameters of the original APG. Some parameters are different though:
 
-- ```-m <length>```: The minimum length of the password to be generated (Default: 20)
+- ```-m <length>```: The minimum length of the password to be generated (Default: 12)
 - ```-x <length>```: The maximum length of the password to be generated (Default: 20)
-- ```-n <number of passwords>```: The amount of passwords to be generated (Default: 1)
+- ```-n <number of passwords>```: The amount of passwords to be generated (Default: 6)
 - ```-E <list of characters>```: Do not use the specified characters in generated passwords
 - ```-M <[LUNSHClunshc]>```: New style password parameters (upper-case enables, lower-case disables)
 - ```-L```: Use lower-case characters in passwords (Default: on)

--- a/apg.go
+++ b/apg.go
@@ -8,8 +8,9 @@ import (
 )
 
 // Constants
-const DefaultPwLenght int = 20
-const VersionString string = "0.3.0"
+const DefaultMinLenght int = 12
+const DefaultMaxLenght int = 20
+const VersionString string = "0.3.1"
 
 type Config struct {
 	minPassLen    int
@@ -37,9 +38,9 @@ apg [-m <length>] [-x <length>] [-L] [-U] [-N] [-S] [-H] [-C]
     [-l] [-M mode] [-E char_string] [-n num_of_pass] [-v] [-h]
 
 Options:
-    -m LENGTH            Minimum length of the password to be generated (Default: 20)
+    -m LENGTH            Minimum length of the password to be generated (Default: 12)
     -x LENGTH            Maximum length of the password to be generated (Default: 20)
-    -n NUMBER            Amount of password to be generated (Default: 1)
+    -n NUMBER            Amount of password to be generated (Default: 6)
     -E CHARS             List of characters to be excluded in the generated password
     -M [LUNSHClunshc]    New style password parameters (upper case: on, lower case: off)
     -L                   Use lower case characters in passwords (Default: on)
@@ -69,11 +70,11 @@ func main() {
 	}
 
 	// Set PW length and available characterset
-	pwLength := getPwLengthFromParams(&config)
 	charRange := getCharRange(&config)
 
 	// Generate passwords
 	for i := 1; i <= config.numOfPass; i++ {
+		pwLength := getPwLengthFromParams(&config)
 		pwString, err := getRandChar(&charRange, pwLength)
 		if err != nil {
 			log.Fatalf("getRandChar returned an error: %q\n", err)

--- a/apg_test.go
+++ b/apg_test.go
@@ -1,6 +1,8 @@
 package main
 
-import "testing"
+import (
+	"testing"
+)
 
 var config Config
 
@@ -45,6 +47,44 @@ func TestGetRandNum(t *testing.T) {
 				if randNum < testCase.minRet {
 					t.Errorf("Random number generation returned too small value. Given %v, expected max: %v, got: %v",
 						testCase.givenVal, testCase.minRet, randNum)
+				}
+			}
+		})
+	}
+}
+
+// Test Pwlength
+func TestGenLength(t *testing.T) {
+	testTable := []struct {
+		testName  string
+		minLength int
+		maxLength int
+	}{
+		{"pwLength defaults", DefaultMinLenght, DefaultMaxLenght},
+		{"pwLength 0 to 1", 0, 1},
+		{"pwLength 1 to 10", 0, 10},
+		{"pwLength 10 to 100", 10, 100},
+	}
+
+	charRange := getCharRange(&config)
+	for _, testCase := range testTable {
+		t.Run(testCase.testName, func(t *testing.T) {
+			config.minPassLen = testCase.minLength
+			config.maxPassLen = testCase.maxLength
+			pwLength := getPwLengthFromParams(&config)
+			for i := 0; i < 1000; i++ {
+				pwString, err := getRandChar(&charRange, pwLength)
+				if err != nil {
+					t.Errorf("getRandChar returned an error: %q", err)
+				}
+				retLen := len(pwString)
+				if retLen > testCase.maxLength {
+					t.Errorf("Generated password length too long. GivenMin %v, GivenMax: %v, Returned length %v",
+						testCase.minLength, testCase.maxLength, retLen)
+				}
+				if retLen < testCase.minLength {
+					t.Errorf("Generated password length too short. GivenMin %v, GivenMax: %v, Returned length %v",
+						testCase.minLength, testCase.maxLength, retLen)
 				}
 			}
 		})

--- a/apg_test.go
+++ b/apg_test.go
@@ -72,7 +72,6 @@ func TestGenLength(t *testing.T) {
 			config.minPassLen = testCase.minLength
 			config.maxPassLen = testCase.maxLength
 			pwLength := getPwLengthFromParams(&config)
-			t.Logf("pwLenght is: %v", pwLength)
 			for i := 0; i < 1000; i++ {
 				pwString, err := getRandChar(&charRange, pwLength)
 				if err != nil {

--- a/apg_test.go
+++ b/apg_test.go
@@ -72,6 +72,7 @@ func TestGenLength(t *testing.T) {
 			config.minPassLen = testCase.minLength
 			config.maxPassLen = testCase.maxLength
 			pwLength := getPwLengthFromParams(&config)
+			t.Logf("pwLenght is: %v", pwLength)
 			for i := 0; i < 1000; i++ {
 				pwString, err := getRandChar(&charRange, pwLength)
 				if err != nil {

--- a/config.go
+++ b/config.go
@@ -18,9 +18,9 @@ func parseFlags() Config {
 	flag.BoolVar(&config.spellPassword, "l", false, "Spell generated password")
 	flag.BoolVar(&config.humanReadable, "H", false, "Generate human-readable passwords")
 	flag.BoolVar(&config.showVersion, "v", false, "Show version")
-	flag.IntVar(&config.minPassLen, "m", DefaultPwLenght, "Minimum password length")
-	flag.IntVar(&config.maxPassLen, "x", DefaultPwLenght, "Maxiumum password length")
-	flag.IntVar(&config.numOfPass, "n", 1, "Number of passwords to generate")
+	flag.IntVar(&config.minPassLen, "m", DefaultMinLenght, "Minimum password length")
+	flag.IntVar(&config.maxPassLen, "x", DefaultMaxLenght, "Maxiumum password length")
+	flag.IntVar(&config.numOfPass, "n", 6, "Number of passwords to generate")
 	flag.StringVar(&config.excludeChars, "E", "", "Exclude list of characters from generated password")
 	flag.StringVar(&config.newStyleModes, "M", "",
 		"New style password parameters (higher priority than single parameters)")
@@ -60,15 +60,16 @@ func parseParams(config *Config) {
 
 // Get the password length from the given cli flags
 func getPwLengthFromParams(config *Config) int {
-	pwLength := config.minPassLen
-	if pwLength < config.minPassLen {
-		pwLength = config.minPassLen
+	if config.minPassLen > config.maxPassLen {
+		config.maxPassLen = config.minPassLen
 	}
-	if pwLength > config.maxPassLen {
-		pwLength = config.maxPassLen
+	lenDiff := config.maxPassLen - config.minPassLen + 1
+	randAdd, err := getRandNum(lenDiff)
+	if err != nil {
+		log.Fatalf("Failed to generated password length: %v", err)
 	}
 
-	return pwLength
+	return config.minPassLen + randAdd
 }
 
 // Parse the new style parameters

--- a/config.go
+++ b/config.go
@@ -68,8 +68,12 @@ func getPwLengthFromParams(config *Config) int {
 	if err != nil {
 		log.Fatalf("Failed to generated password length: %v", err)
 	}
+	retVal := config.minPassLen + randAdd
+	if retVal <= 0 {
+		return 1
+	}
 
-	return config.minPassLen + randAdd
+	return retVal
 }
 
 // Parse the new style parameters

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/wneessen/apg.go
+module github.com/wneessen/apg-go
 
 go 1.16


### PR DESCRIPTION
To address issue #13, the password length behaviour of the
original APG has been reproduced. Previously, when a minLength
of 5 and a maxLength of 10 was given, apg-go se the pwLength to
the preferred maxLength.

With v0.3.1 it will choose a random length between minLength and
maxLength instead, same as the original C-lang apg did. For this
the minLength has been defaulted to a sane value of 12 (instead
of the 8 of the original apg). The default for maxLength stayed
at 20.

Also the default number of generated passwords has been changed
from 1 to 6, to replicate the behaviour of the original apg.