### PR TITLE
Dockerfile was accidentally forcing GOOS and GOARCH.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:latest as builder
 RUN mkdir /builddir
 ADD . /builddir/
 WORKDIR /builddir
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags '-w -s -extldflags "-static"' -o apg-go \
+RUN CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags '-w -s -extldflags "-static"' -o apg-go \
     github.com/wneessen/apg-go/cmd/apg
 
 ## Create scratch image

--- a/cmd/apg/apg.go
+++ b/cmd/apg/apg.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wneessen/go-hibp"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -57,6 +58,7 @@ func main() {
 	// Show version and exit
 	if cfgObj.ShowVersion {
 		_, _ = os.Stderr.WriteString(`apg-go // A "Automated Password Generator"-clone v` + VersionString + "\n")
+		_, _ = os.Stderr.WriteString("OS: " + runtime.GOOS + " // Arch: " + runtime.GOARCH + " \n")
 		_, _ = os.Stderr.WriteString("(C) 2021 by Winni Neessen\n")
 		os.Exit(0)
 	}


### PR DESCRIPTION
For each of use, the version now also prints out OS and ARCH