### PR TITLE
Add SPDX license headers in scorecard.yml

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # This workflow uses actions that are not certified by GitHub. They are provided
 # by a third-party and are governed by separate terms of service, privacy
 # policy, and support documentation.


### PR DESCRIPTION
SPDX-FileCopyrightText and SPDX-License-Identifier license headers have been added to the top of the scorecard.yml file. The headers pertain to the 2022 copyright of Winni Neessen and define the license to be CC0-1.0.