### PR TITLE
Add read permissions to GitHub workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -83,7 +83,7 @@ jobs:
 
     - run: |
         echo "Build Application using Go"
-        /usr/bin/env GOTOOLCHAIN=go1.22.1+auto go build -ldflags '-s -w' -o apg github.com/wneessen/apg-go/cmd/apg
+        /usr/bin/env GOTOOLCHAIN=go1.22.1+auto go build -a -installsuffix cgo -ldflags '-w -s -extldflags "-static"' -o apg github.com/wneessen/apg-go/cmd/apg
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: CC0-1.0
 
 name: REUSE Compliance Check
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
The reuse and docker-publish workflow scripts in GitHub Actions have been updated. Now these scripts have permission to read contents. This will ensure secure access and controlled operations on repositories.