### PR TITLE
Update workflows to trigger on specific file changes

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - '**.go'
       - 'go.*'
-      - '.github/**'
+      - '.github/workflow/codecov.yml'
       - 'codecov.yml'
   pull_request:
     branches:
@@ -19,7 +19,7 @@ on:
     paths:
       - '**.go'
       - 'go.*'
-      - '.github/**'
+      - '.github/workflow/codecov.yml'
       - 'codecov.yml'
 jobs:
   run:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,10 +14,20 @@ on:
     - cron: '24 12 * * *'
   push:
     branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.*'
+      - '.github/workflow/docker-publish.yml'
+      - 'codecov.yml'
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.*'
+      - '.github/workflow/docker-publish.yml'
+      - 'codecov.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,7 +9,17 @@ on:
       - v*
     branches:
       - main
+    paths:
+      - '**.go'
+      - 'go.*'
+      - '.github/workflow/golangci-lint.yml'
+      - 'codecov.yml'
   pull_request:
+    paths:
+      - '**.go'
+      - 'go.*'
+      - '.github/workflow/golangci-lint.yml'
+      - 'codecov.yml'
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -8,6 +8,11 @@ on:
   push:
     branches:
       - main # or the name of your main branch
+    paths:
+      - '**.go'
+      - 'go.*'
+      - '.github/workflow/sonarqube.yml'
+      - 'codecov.yml'
 jobs:
   build:
     name: Build


### PR DESCRIPTION
The update limits the GolangCI, Codecov, SonarQube, and Docker workflow triggers to only fire when specific related files are modified. By focusing on relevant paths like '**.go', 'go.*' and respective workflow files, we enhance the efficiency of our CI/CD process.